### PR TITLE
Add a script to delete stale subscriptions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ with that.
 # Usage
 
 ~~~
-$./rhsmShowConsumerSubs.py -l rh_user_account
+$python rhsmShowConsumerSubs.py -l rh_user_account
+$python rhDeleteStaleSubs.py -lrh_user-account --last-checkin 2016-07-05
 ~~~
 
 # Notes

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 # rhsmShowConsumerSubs
 Script to Display Subscriptions consumed on Red Hat Subscription Management (RHSM)
 
+# rhDeleteStaleSubs.py
+Script to Unregister systems that didn't check-in with RHSM since a given date.
+
 # Overview
 
 When working with Red Hat Subscription Management (RHSM), I have found the need
-to easily identify which systems are consuming which subscriptions. This script assists
-with that.
+to easily identify which systems are consuming which subscriptions. The script 
+rhsmShowConsumerSubs assists with that.
+
+If you have systems that did not check-in with Red Hat Subscription Management 
+(RHSM) for several days/weeks, it is likely that they are either powered off 
+or deleted (in the case of a cloud/virtualized environment). 
+rhDeleteStaleSubs.py will detect which systems haven't checked in since a 
+given date YYYY-MM-DD and ask for confirmation to unregister them. There is
+also a --force option to skip the confirmation and a --filter option to match 
+a certain hostname pattern.
 
 # Requirements
 
@@ -16,12 +27,12 @@ with that.
 
 ~~~
 $python rhsmShowConsumerSubs.py -l rh_user_account
-$python rhDeleteStaleSubs.py -lrh_user-account --last-checkin 2016-07-05
+$python rhDeleteStaleSubs.py -lrh_user-account --last-checkin 2016-06-05 
 ~~~
 
 # Notes
 
-* The script will prompt for password if not provided
+* The scripts will prompt for password if not provided
 * The **https_proxy** environmental variable, if set, will be used to connect via a proxy
 
 ### Example Output
@@ -43,4 +54,14 @@ satellite.example.net,system,12345678,Red Hat Enterprise Linux Server, Premium (
 satellite.example.net,system,12345678,Red Hat Enterprise Linux Server, Standard (Physical or Virtual Nodes),2014-10-08T04:00:00.000+0000,2015-10-08T03:59:59.000+0000,24,2015-08-02T10:42:24.000+0000,admin_user
 satellite.example.org,system,12345678,Red Hat Satellite,2014-10-08T04:00:00.000+0000,2015-10-08T03:59:59.000+0000,10,2015-08-02T10:42:24.000+0000,admin_user
 satellite.example.net,system,12345678,Red Hat Satellite,2014-10-08T04:00:00.000+0000,2015-10-08T03:59:59.000+0000,10,2015-08-02T10:42:24.000+0000,admin_user
+
+$./rhDeleteStaleSubs.py -l rh_user_account --last-checkin 2016-07-04 --filter test
+[DEBUG] Authentication successful
+[DEBUG] Grabbing a list of systems
+[DEBUG] Checking 28 subscribed systems...
+Hostname: rhel6-test UUID:25483352-524a-4c24-9072-c484dc7829a9 last checked-in 2016-05-12 which is older than 2016-07-04
+Unregister? y/n n
+Hostname: rhel7-test UUID:a5675b75-746f-49ed-8631-c48a275f8495 last checked-in 2016-05-26 which is older than 2016-07-04
+Unregister? y/n y
+Removing System's Subscription from RHSM...
 ~~~

--- a/rhDeleteStaleSubs.py
+++ b/rhDeleteStaleSubs.py
@@ -30,6 +30,7 @@ parser = OptionParser()
 parser.add_option("-l", "--login", dest="login", help="Login user for RHSM", metavar="LOGIN")
 parser.add_option("-p", "--password", dest="password", help="Password for specified user. Will prompt if omitted", metavar="PASSWORD")
 parser.add_option("-c", "--last-checkin", dest="checkin", help="Last Date a System checked in with RHSM, format yyyy-mm-dd", metavar="CHECK-IN")
+parser.add_option("-t", "--filter", dest="filter", help="Pattern to filter hostnames against, for example: -f 'ip-10-234' will match systems containing that pattern in their hostname field.", metavar="FILTER")
 parser.add_option("-f", "--force", dest="force", help="Do not ask prompt for confirmation, unregister all systems that match the last-checkin criteria", default=False, action='store_true')
 (options, args) = parser.parse_args()
 
@@ -43,6 +44,7 @@ else:
     password = options.password
     checkin = options.checkin
     force = options.force
+    filter = options.filter
 
 try:
     date_reference = datetime.strptime(checkin, '%Y-%m-%d')
@@ -51,6 +53,8 @@ except ValueError:
     print "Incorrect Date format. Please use %Y-%m-%d. Example usage: ./rhDeleteStaleSubs.py -l rh_user_account -c 2016-02-10"
     sys.exit(1)
 
+if filter is None:
+	filter = ''
 if not password: password = getpass.getpass("%s's password:" % login)
 
 if hasattr(ssl, '_create_unverified_context'):
@@ -103,7 +107,7 @@ for consumer in consumerdata:
 	consumerType = consumer["type"]["label"]
 	lastCheckin = consumer["lastCheckin"]
 	factsurl = "https://" + portal_host + "/subscription" + consumer["href"] + "/"
-	if lastCheckin is not None:
+	if lastCheckin is not None and filter in consumer["name"] :
 		date = parse_date(lastCheckin)
 		lastCheckin_date = date.replace(tzinfo=None)
 		lastCheckin_date = lastCheckin_date.strftime("%Y-%m-%d")

--- a/rhDeleteStaleSubs.py
+++ b/rhDeleteStaleSubs.py
@@ -45,7 +45,8 @@ else:
     force = options.force
 
 try:
-    dt_reference = datetime.strptime(checkin, '%Y-%m-%d')
+    date_reference = datetime.strptime(checkin, '%Y-%m-%d')
+    date_reference = date_reference.strftime("%Y-%m-%d")
 except ValueError:
     print "Incorrect Date format. Please use %Y-%m-%d. Example usage: ./rhDeleteStaleSubs.py -l rh_user_account -c 2016-02-10"
     sys.exit(1)
@@ -98,17 +99,17 @@ print "[DEBUG] Checking %i subscribed systems..." %(len(consumerdata))
 # Now that we have a list of Consumers, loop through them and 
 # verify the LastCheckin date associated with them. 
 for consumer in consumerdata:
-	print "[DEBUG] Checking Hostname %s UUID %s" %(consumer["name"], consumer["uuid"])
+	#print "[DEBUG] Checking Hostname %s UUID %s" %(consumer["name"], consumer["uuid"])
 	consumerType = consumer["type"]["label"]
 	lastCheckin = consumer["lastCheckin"]
 	factsurl = "https://" + portal_host + "/subscription" + consumer["href"] + "/"
 	if lastCheckin is not None:
-		dt = parse_date(lastCheckin)
-		dt_no_tzinfo = dt.replace(tzinfo=None)
-		if dt_no_tzinfo <= dt_reference:
+		date = parse_date(lastCheckin)
+		lastCheckin_date = date.replace(tzinfo=None)
+		lastCheckin_date = lastCheckin_date.strftime("%Y-%m-%d")
+		if lastCheckin_date <= date_reference:
 			print "Hostname: %s UUID:%s last checked-in %s which is older than %s" % (consumer["name"],
-				consumer["uuid"], dt_no_tzinfo.strftime("%Y-%m-%d"), 
-				dt_reference.strftime("%Y-%m-%d"))
+				consumer["uuid"], lastCheckin_date, date_reference)
 			choice = None
 			if not options.force: 
 				choice = raw_input("Unregister? y/n ").lower()

--- a/rhDeleteStaleSubs.py
+++ b/rhDeleteStaleSubs.py
@@ -2,9 +2,9 @@
 
 # File: rhDeleteStaleSubs.py
 # Author: Zaina Afoulki <zaina@redhat.com>
-# Purpose: Given a username, password and date, delete subscription
-#                   for systems that didn't check in with RHSM  
-#                   since the provided date.
+# Purpose: Given a username, password and date, delete subscriptions
+#                   for systems that didn't check in with RHSM since
+#                   the provided date.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@
 # GNU General Public License for more details.
 
 import json
+import httplib
 import getpass
 import urllib2
 import base64
@@ -28,8 +29,8 @@ from datetime import datetime
 parser = OptionParser()
 parser.add_option("-l", "--login", dest="login", help="Login user for RHSM", metavar="LOGIN")
 parser.add_option("-p", "--password", dest="password", help="Password for specified user. Will prompt if omitted", metavar="PASSWORD")
-parser.add_option("-d", "--debug", dest='debug',help="print more details for debugging" , default=False, action='store_true')
-parser.add_option("-c", "--last-checkin", dest="checkin", help="Last Check in Date in the format yyyy-mm-dd", metavar="CHECKIN")
+parser.add_option("-c", "--last-checkin", dest="checkin", help="Last Date a System checked in with RHSM, format yyyy-mm-dd", metavar="CHECK-IN")
+parser.add_option("-f", "--force", dest="force", help="Do not ask prompt for confirmation, unregister all systems that match the last-checkin criteria", default=False, action='store_true')
 (options, args) = parser.parse_args()
 
 if not ( options.login ):
@@ -41,14 +42,13 @@ else:
     login = options.login
     password = options.password
     checkin = options.checkin
-
-yes = set(['yes','y', 'ye', ''])
-no = set(['no','n'])
+    force = options.force
 
 try:
     dt_reference = datetime.strptime(checkin, '%Y-%m-%d')
 except ValueError:
-    print "Incorrect format"
+    print "Incorrect Date format. Please use %Y-%m-%d. Example usage: ./rhDeleteStaleSubs.py -l rh_user_account -c 2016-02-10"
+    sys.exit(1)
 
 if not password: password = getpass.getpass("%s's password:" % login)
 
@@ -60,8 +60,6 @@ portal_host = "subscription.rhn.redhat.com"
 url = "https://" + portal_host + "/subscription/users/" + login + "/owners/"
 try:
  	request = urllib2.Request(url)
-        if options.debug :
-            print "Attempting to connect: " + url
 	base64string = base64.encodestring('%s:%s' % (login, password)).strip()
 	request.add_header("Authorization", "Basic %s" % base64string)
 	result = urllib2.urlopen(request)
@@ -79,9 +77,6 @@ for accounts in accountdata:
 
 #### Grab a list of Consumers
 url = "https://" + portal_host + "/subscription/owners/" + acct + "/consumers/"
-if options.debug :
-     print "Attempting to connect: " + url
-
 try:
  	request = urllib2.Request(url)
 	base64string = base64.encodestring('%s:%s' % (login, password)).strip()
@@ -103,8 +98,6 @@ for consumer in consumerdata:
 	consumerType = consumer["type"]["label"]
 	lastCheckin = consumer["lastCheckin"]
 	factsurl = "https://" + portal_host + "/subscription" + consumer["href"] + "/"
-        if options.debug :
-            print "Attempting to connect: " + factsurl
 	try:
 		sysinfo = urllib2.Request(factsurl)
 		base64string = base64.encodestring('%s:%s' % (login, password)).strip()
@@ -133,14 +126,21 @@ for consumer in consumerdata:
 		dt = parse_date(lastCheckin)
 		dt_no_tzinfo = dt.replace(tzinfo=None)
 		if dt_no_tzinfo <= dt_reference:
-			print "%s IP %s last checked-in %s which is older than %s. Delete? y/n" % (consumer["name"],ipaddr,dt_no_tzinfo,dt_reference)
-			choice = raw_input().lower()
-			if choice in yes:
-				# Delete System's Subscription from RHSM
+			print "Hostname: %s IP:%s UUID:%s last checked-in %s which is older than %s" % (consumer["name"],ipaddr,consumer["uuid"],dt_no_tzinfo.strftime("%Y-%m-%d"),dt_reference.strftime("%Y-%m-%d"))
+			choice = None
+			if not options.force: 
+				choice = raw_input("Unregister? y/n ").lower()
+			if choice in ['yes','y', 'YES', 'Y'] or options.force:
 				print "Removing System's Subscription from RHSM..."
-			elif choice in no:
-				# Skip this System
-				pass
+				try:
+					request = urllib2.Request(factsurl)
+					base64string = base64.encodestring('%s:%s' % (login, password)).strip()
+					request.add_header("Authorization", "Basic %s" % base64string)
+					request.get_method = lambda: 'DELETE'
+					result = urllib2.urlopen(request)
+				except Exception, e:
+					print "FATAL Error - %s" % (e)
+			
 			else:
-			   sys.stdout.write("Please respond with 'yes' or 'no'")
+				pass
 sys.exit(0)

--- a/rhDeleteStaleSubs.py
+++ b/rhDeleteStaleSubs.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+# File: rhDeleteStaleSubs.py
+# Author: Zaina Afoulki <zaina@redhat.com>
+# Purpose: Given a username, password and date, delete subscription
+#                   for systems that didn't check in with RHSM  
+#                   since the provided date.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import json
+import getpass
+import urllib2
+import base64
+import sys
+import ssl
+from optparse import OptionParser
+from dateutil.parser import parse as parse_date
+from datetime import datetime
+
+parser = OptionParser()
+parser.add_option("-l", "--login", dest="login", help="Login user for RHSM", metavar="LOGIN")
+parser.add_option("-p", "--password", dest="password", help="Password for specified user. Will prompt if omitted", metavar="PASSWORD")
+parser.add_option("-d", "--debug", dest='debug',help="print more details for debugging" , default=False, action='store_true')
+parser.add_option("-c", "--last-checkin", dest="checkin", help="Last Check in Date in the format yyyy-mm-dd", metavar="CHECKIN")
+(options, args) = parser.parse_args()
+
+if not ( options.login ):
+	print "Must specify a login (will prompt for password if omitted).  See usage:"
+	parser.print_help()
+	print "\nExample usage: ./rhDeleteStaleSubs.py -l rh_user_account -c 2016-02-10"
+	sys.exit(1)
+else:
+    login = options.login
+    password = options.password
+    checkin = options.checkin
+
+yes = set(['yes','y', 'ye', ''])
+no = set(['no','n'])
+
+try:
+    dt_reference = datetime.strptime(checkin, '%Y-%m-%d')
+except ValueError:
+    print "Incorrect format"
+
+if not password: password = getpass.getpass("%s's password:" % login)
+
+if hasattr(ssl, '_create_unverified_context'):
+	        ssl._create_default_https_context = ssl._create_unverified_context
+
+portal_host = "subscription.rhn.redhat.com"
+
+url = "https://" + portal_host + "/subscription/users/" + login + "/owners/"
+try:
+ 	request = urllib2.Request(url)
+        if options.debug :
+            print "Attempting to connect: " + url
+	base64string = base64.encodestring('%s:%s' % (login, password)).strip()
+	request.add_header("Authorization", "Basic %s" % base64string)
+	result = urllib2.urlopen(request)
+except urllib2.URLError, e:
+	print "Error: cannot connect to the API: %s" % (e)
+	print "Check your URL & try to login using the same user/pass via the WebUI and check the error!"
+	sys.exit(1)
+except:
+	print "FATAL Error - %s" % (e)
+	sys.exit(2)
+
+accountdata = json.load(result)
+for accounts in accountdata:
+	acct = accounts["key"]
+
+#### Grab a list of Consumers
+url = "https://" + portal_host + "/subscription/owners/" + acct + "/consumers/"
+if options.debug :
+     print "Attempting to connect: " + url
+
+try:
+ 	request = urllib2.Request(url)
+	base64string = base64.encodestring('%s:%s' % (login, password)).strip()
+	request.add_header("Authorization", "Basic %s" % base64string)
+	result = urllib2.urlopen(request)
+except urllib2.URLError, e:
+	print "Error: cannot connect to the API: %s" % (e)
+	print "Check your URL & try to login using the same user/pass via the WebUI and check the error!"
+	sys.exit(1)
+except:
+	print "FATAL Error - %s" % (e)
+	sys.exit(2)
+
+consumerdata = json.load(result)
+
+#### Now that we have a list of Consumers, loop through them and 
+#### verify the LastCheckin date associated with them. 
+for consumer in consumerdata:
+	consumerType = consumer["type"]["label"]
+	lastCheckin = consumer["lastCheckin"]
+	factsurl = "https://" + portal_host + "/subscription" + consumer["href"] + "/"
+        if options.debug :
+            print "Attempting to connect: " + factsurl
+	try:
+		sysinfo = urllib2.Request(factsurl)
+		base64string = base64.encodestring('%s:%s' % (login, password)).strip()
+		sysinfo.add_header("Authorization", "Basic %s" % base64string)
+		sysresult = urllib2.urlopen(sysinfo)
+		sysdata = json.load(sysresult)
+	except Exception, e:
+		print "FATAL Error - %s" % (e)
+		sys.exit(1)
+	if sysdata['facts'].has_key('network.ipv4_address'):
+		ipaddr = sysdata['facts']['network.ipv4_address']
+	else:
+		ipaddr = "Unknown"
+
+	detailedurl = "https://" + portal_host + "/subscription" + consumer["href"] + "/entitlements/"
+	try:
+		sysinfo = urllib2.Request(detailedurl)
+		base64string = base64.encodestring('%s:%s' % (login, password)).strip()
+		sysinfo.add_header("Authorization", "Basic %s" % base64string)
+		sysresult = urllib2.urlopen(sysinfo)
+		sysdata = json.load(sysresult)
+	except Exception, e:
+		print "FATAL Error - %s" % (e)
+		sys.exit(1)
+	for products in sysdata:
+		dt = parse_date(lastCheckin)
+		dt_no_tzinfo = dt.replace(tzinfo=None)
+		if dt_no_tzinfo <= dt_reference:
+			print "%s IP %s last checked-in %s which is older than %s. Delete? y/n" % (consumer["name"],ipaddr,dt_no_tzinfo,dt_reference)
+			choice = raw_input().lower()
+			if choice in yes:
+				# Delete System's Subscription from RHSM
+				print "Removing System's Subscription from RHSM..."
+			elif choice in no:
+				# Skip this System
+				pass
+			else:
+			   sys.stdout.write("Please respond with 'yes' or 'no'")
+sys.exit(0)

--- a/rhDeleteStaleSubs.py
+++ b/rhDeleteStaleSubs.py
@@ -97,44 +97,18 @@ consumerdata = json.load(result)
 for consumer in consumerdata:
 	consumerType = consumer["type"]["label"]
 	lastCheckin = consumer["lastCheckin"]
+	factsurl = "https://" + portal_host + "/subscription" + consumer["href"] + "/"
 	if lastCheckin is not None:
 		dt = parse_date(lastCheckin)
 		dt_no_tzinfo = dt.replace(tzinfo=None)
-	factsurl = "https://" + portal_host + "/subscription" + consumer["href"] + "/"
-	try:
-		sysinfo = urllib2.Request(factsurl)
-		base64string = base64.encodestring('%s:%s' % (login, password)).strip()
-		sysinfo.add_header("Authorization", "Basic %s" % base64string)
-		sysresult = urllib2.urlopen(sysinfo)
-		sysdata = json.load(sysresult)
-	except Exception, e:
-		print "FATAL Error - %s" % (e)
-		sys.exit(1)
-	if sysdata['facts'].has_key('network.ipv4_address'):
-		ipaddr = sysdata['facts']['network.ipv4_address']
-	else:
-		ipaddr = "Unknown"
-
-	detailedurl = "https://" + portal_host + "/subscription" + consumer["href"] + "/entitlements/"
-	try:
-		sysinfo = urllib2.Request(detailedurl)
-		base64string = base64.encodestring('%s:%s' % (login, password)).strip()
-		sysinfo.add_header("Authorization", "Basic %s" % base64string)
-		sysresult = urllib2.urlopen(sysinfo)
-		sysdata = json.load(sysresult)
-	except Exception, e:
-		print "FATAL Error - %s" % (e)
-		sys.exit(1)
-
-	for products in sysdata:
-		if lastCheckin is not None and dt_no_tzinfo <= dt_reference:
-			print "Hostname: %s IP:%s UUID:%s last checked-in %s which is older than %s" % (consumer["name"],
-				ipaddr, consumer["uuid"], dt_no_tzinfo.strftime("%Y-%m-%d"), 
+		if dt_no_tzinfo <= dt_reference:
+			print "Hostname: %s UUID:%s last checked-in %s which is older than %s" % (consumer["name"],
+				consumer["uuid"], dt_no_tzinfo.strftime("%Y-%m-%d"), 
 				dt_reference.strftime("%Y-%m-%d"))
 			choice = None
 			if not options.force: 
 				choice = raw_input("Unregister? y/n ").lower()
-			if choice in ['yes','y', 'YES', 'Y'] or options.force:
+			if choice in ['yes','y'] or options.force:
 				print "Removing System's Subscription from RHSM..."
 				try:
 					request = urllib2.Request(factsurl)

--- a/rhDeleteStaleSubs.py
+++ b/rhDeleteStaleSubs.py
@@ -71,11 +71,13 @@ except Exception, e:
 	print "FATAL Error - %s" % (e)
 	sys.exit(2)
 
+print "[DEBUG] Authentication successful"
 accountdata = json.load(result)
 for accounts in accountdata:
 	acct = accounts["key"]
 
-#### Grab a list of Consumers
+# Grab a list of Consumers
+print "[DEBUG] Grabbing a list of systems"
 url = "https://" + portal_host + "/subscription/owners/" + acct + "/consumers/"
 try:
  	request = urllib2.Request(url)
@@ -91,10 +93,12 @@ except Exception, e:
 	sys.exit(2)
 
 consumerdata = json.load(result)
+print "[DEBUG] Checking %i subscribed systems..." %(len(consumerdata))
 
-#### Now that we have a list of Consumers, loop through them and 
-#### verify the LastCheckin date associated with them. 
+# Now that we have a list of Consumers, loop through them and 
+# verify the LastCheckin date associated with them. 
 for consumer in consumerdata:
+	print "[DEBUG] Checking Hostname %s UUID %s" %(consumer["name"], consumer["uuid"])
 	consumerType = consumer["type"]["label"]
 	lastCheckin = consumer["lastCheckin"]
 	factsurl = "https://" + portal_host + "/subscription" + consumer["href"] + "/"


### PR DESCRIPTION
Given a username, password and date, delete subscriptions for systems that didn't check in with RHSM since a user provided date in the format YYYY-MM-DD.

If you have systems that did not check-in with Red Hat Subscription Management  (RHSM) for several days/weeks, it is likely that they are either powered off or deleted (in the case of a cloud/virtualized environment).

rhDeleteStaleSubs.py will detect which systems haven't checked in since a given date YYYY-MM-DD and ask for confirmation to unregister them. There is also a --force option to skip the confirmation and a --filter option to match a certain hostname pattern.
